### PR TITLE
overScheme_op_equiv_under

### DIFF
--- a/EllipticCurve/AlgebraicGeometry/OverScheme.lean
+++ b/EllipticCurve/AlgebraicGeometry/OverScheme.lean
@@ -268,8 +268,8 @@ noncomputable def costructuredArrow_affineScheme_op_equiv_under (R : CommRingCat
     StructuredArrow.map₂ (F := AffineScheme.Spec.rightOp) (𝟙 _) (𝟙 _)
   (costructuredArrowOpEquivalence _ _).trans (F₁ ⋙ F₂.asEquivalence.inverse).asEquivalence
 
-/-- Equivalence between `CostructuredArrow` and that for the essential image subcategory. -/
-noncomputable def costructuredArrow_equiv_essImageSubcategory (R : CommRingCat.{u}) :
+/-- Equivalence between `CostructuredArrow` for `AffineScheme`, and `OverScheme`. -/
+noncomputable def costructuredArrow_affineScheme_equiv_overScheme (R : CommRingCat.{u}) :
     CostructuredArrow AffineScheme.Spec (AffineScheme.of (Spec R)) ≌
     OverScheme (Spec R) :=
   (CostructuredArrow.map₂ (F := 𝟭 CommRingCatᵒᵖ) (G := AffineScheme.forgetToScheme)
@@ -279,7 +279,7 @@ noncomputable def costructuredArrow_equiv_essImageSubcategory (R : CommRingCat.{
 the opposite category of affine schemes over `Spec R`. -/
 noncomputable def overScheme_op_equiv_under (R : CommRingCat.{u}) :
     (OverScheme (Spec R))ᵒᵖ ≌ Under R :=
-  (costructuredArrow_equiv_essImageSubcategory R).inverse.asEquivalence.op.trans
+  (costructuredArrow_affineScheme_equiv_overScheme R).inverse.asEquivalence.op.trans
     (costructuredArrow_affineScheme_op_equiv_under R)
 
 namespace OverScheme

--- a/EllipticCurve/AlgebraicGeometry/OverScheme.lean
+++ b/EllipticCurve/AlgebraicGeometry/OverScheme.lean
@@ -6,6 +6,7 @@ Authors: Kenny Lau
 
 import EllipticCurve.AlgebraicGeometry.BigAffineZariski
 import EllipticCurve.CategoryTheory.PresheafCostructured
+import Mathlib.AlgebraicGeometry.AffineScheme
 
 /-!
 # The Category of Commutative Rings Over a Scheme
@@ -247,8 +248,23 @@ end CategoryTheory.CostructuredArrow
 
 namespace CommRingCat
 
+-- this shouldn't be in CommRingCat (?), but we put it here for now
+/-- The category of affine schemes over a fixed base scheme `𝒮`. -/
 abbrev OverScheme (𝒮 : Scheme.{u}) : Type (u + 1) :=
   CostructuredArrow Scheme.Spec 𝒮
+
+instance : AffineScheme.Spec.IsEquivalence where
+
+/-- The category of commutative rings under `R` is equivalent to
+the opposite category of affine schemes over `Spec R`. -/
+noncomputable def underEquivOverSpec (R : CommRingCat.{u}) :
+    (CostructuredArrow AffineScheme.Spec (AffineScheme.of (Spec R)))ᵒᵖ ≌ Under R := by
+  refine (costructuredArrowOpEquivalence _ _).trans ?_
+  unfold Under
+  -- #synth AffineScheme.Spec.op.IsEquivalence
+  -- #check pre (op (AffineScheme.of (Spec R)))
+  sorry
+
 
 namespace OverScheme
 

--- a/EllipticCurve/AlgebraicGeometry/OverScheme.lean
+++ b/EllipticCurve/AlgebraicGeometry/OverScheme.lean
@@ -253,18 +253,34 @@ namespace CommRingCat
 abbrev OverScheme (𝒮 : Scheme.{u}) : Type (u + 1) :=
   CostructuredArrow Scheme.Spec 𝒮
 
-instance : AffineScheme.Spec.IsEquivalence where
+-- mathlib #29927
+instance {C : Type*} [Category C] {D : Type*} [Category D]
+    {F : C ⥤ D} [F.Faithful] [F.Full] [F.EssSurj] : F.IsEquivalence where
 
 /-- The category of commutative rings under `R` is equivalent to
 the opposite category of affine schemes over `Spec R`. -/
-noncomputable def underEquivOverSpec (R : CommRingCat.{u}) :
-    (CostructuredArrow AffineScheme.Spec (AffineScheme.of (Spec R)))ᵒᵖ ≌ Under R := by
-  refine (costructuredArrowOpEquivalence _ _).trans ?_
-  unfold Under
-  -- #synth AffineScheme.Spec.op.IsEquivalence
-  -- #check pre (op (AffineScheme.of (Spec R)))
-  sorry
+noncomputable def costructuredArrow_affineScheme_op_equiv_under (R : CommRingCat.{u}) :
+    (CostructuredArrow AffineScheme.Spec (AffineScheme.of (Spec R)))ᵒᵖ ≌ Under R :=
+  let F₁ := StructuredArrow.pre (op (AffineScheme.of (Spec R))) AffineScheme.Spec.op (𝟭 _)
+  let F₂ :
+      StructuredArrow R (𝟭 CommRingCat) ⥤
+      StructuredArrow (AffineScheme.Spec.rightOp.obj R) (𝟭 AffineSchemeᵒᵖ) :=
+    StructuredArrow.map₂ (F := AffineScheme.Spec.rightOp) (𝟙 _) (𝟙 _)
+  (costructuredArrowOpEquivalence _ _).trans (F₁ ⋙ F₂.asEquivalence.inverse).asEquivalence
 
+/-- Equivalence between `CostructuredArrow` and that for the essential image subcategory. -/
+noncomputable def costructuredArrow_equiv_essImageSubcategory (R : CommRingCat.{u}) :
+    CostructuredArrow AffineScheme.Spec (AffineScheme.of (Spec R)) ≌
+    OverScheme (Spec R) :=
+  (CostructuredArrow.map₂ (F := 𝟭 CommRingCatᵒᵖ) (G := AffineScheme.forgetToScheme)
+    (𝟙 _) (𝟙 _)).asEquivalence
+
+/-- The category of commutative rings under `R` is equivalent to
+the opposite category of affine schemes over `Spec R`. -/
+noncomputable def overScheme_op_equiv_under (R : CommRingCat.{u}) :
+    (OverScheme (Spec R))ᵒᵖ ≌ Under R :=
+  (costructuredArrow_equiv_essImageSubcategory R).inverse.asEquivalence.op.trans
+    (costructuredArrow_affineScheme_op_equiv_under R)
 
 namespace OverScheme
 


### PR DESCRIPTION
`overScheme_op_equiv_under`: equivalence between the category of commutative rings under `R` and the opposite category of affine schemes over `Spec R`. 